### PR TITLE
Now that the radio is fully protected, the frequency scan or frequenc…

### DIFF
--- a/radioDiags/src_diags/diagUi.cc
+++ b/radioDiags/src_diags/diagUi.cc
@@ -1051,10 +1051,6 @@ static void cmdStopReceiver(char *bufferPtr)
 
   if (enabled)
   {
-    // Stop the scanner and sweeper if they're running.
-    cmdStopFscan(bufferPtr);
-    cmdStopFrequencySweep(bufferPtr);
-
     // Stop the receiverr.
     diagUi_radioPtr->stopReceiver();
 


### PR DESCRIPTION
…y sweep

no longer have to be terminated before the receiver is stopped.  Having a
mutex in the Radio object eliminated all race conditions.  This manifested
itself by an I2C register write failure (occasionally) when I would stop
the receiver, keeping in mind that the frequency scanner will tune the
radio to a different frequency every 64ms.