### PR TITLE
This commit incorporates the changes listed below:

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -92,7 +92,8 @@ set rxwarp <warp in ppm>
 set squelch <threshold>
 start receiver
 stop receiver
-start fscan <startfrequency> <endfrequency> <stepsize>
+set fscanvalues <startfrequency> <endfrequency> <stepsize>
+start fscan
 stop fscan
 start frequencysweep <startfrequency> <stepsize> <count> <dwelltime>
 stop frequencysweep
@@ -166,9 +167,40 @@ Demodulator Gain         : 300.000000
 
 ******************** End Get Radio Info Output *************************
 
+The new features I have added are listed below:
 
-Anyway, if you have any questions, you can always catch me on freenode IRC.
-I use the nick wizardyesterday or adhoc_rf_rocks.
+1. A signal squelch that works directly with the average magnitude of
+a received IQ data block.
+
+2. A frequency scanner that lets you specify a start frequency, an end
+frequency, and a frequency step. This collaborates with the squelch
+such that, when scanning, if a signal exceeds the squelch threshold,
+the scan will stop so that you can hear the demodulated audio of the
+signal. When the signal goes away, frequency scan will continue.
+
+When the user types "get fscaninfo" (for the frequency scanner), the
+output appears as illustratedbelow.  Not that the start frequency, the
+end frequency, and the frequency increment are configurable.  See the
+help command output for the syntax of the commands realated to the
+frequency scanner (fscan).
+
+******************** Begin GetFscainfo Info Output **********************
+
+--------------------------------------------
+Frequency Scanner Internal Information
+--------------------------------------------
+Scanner State             : Scanning
+Start Frequency           : 120350000 Hz
+End Frequency             : 120550000 Hz
+Frequency Increment       : 25000 Hz
+Current Frequency         : 120475000 Hz
+
+******************** End Get Fscainfo Output  **** **********************
+
+
+Anyway, if you have any questions, you can always catch me on libera IRC.
+I use the nick wizardyesterday.  I can also be reached on Facebook as
+Chris Gianakopoulos.
 
 Oh one last thing.  Anybody can use my software without grief.  I guess I'll
 have to put the GNU open source stuff at the beginning of my files, and that

--- a/radioDiags/hdr_diags/FrequencyScanner.h
+++ b/radioDiags/hdr_diags/FrequencyScanner.h
@@ -18,13 +18,17 @@ class FrequencyScanner
 
   enum state_t {Idle, Scanning};
 
-  FrequencyScanner(Radio *radioPtr,
-                   uint64_t startFrequencyInHertz,
-                   uint64_t endFrequencyInHertz,
-                   uint64_t frequencyIncrementInHertz);
+  FrequencyScanner(Radio *radioPtr);
 
   ~FrequencyScanner(void);
 
+  bool setScanParameters(uint64_t startFrequencyInHertz,
+                         uint64_t endFrequencyInHertz,
+                         uint64_t frequencyIncrementInHertz);
+
+  bool start(void);
+  bool stop(void);
+  bool isScanning(void);
   void run(bool signalPresent);
 
   void displayInternalInformation(void);
@@ -51,11 +55,14 @@ class FrequencyScanner
   // The end frequency of the sweep.
   uint64_t endFrequencyInHertz;
 
-  // The current frequency for display purposes.
-  uint64_t currentFrequencyInHertz;
-
   // The frequency step size to take during a scan.
   uint64_t frequencyIncrementInHertz;
+
+  // This indicates when no scan parameters are available.
+  bool newConfigurationAvailable;
+
+  // The current frequency of the sweep.
+  uint64_t currentFrequencyInHertz;
 
   // Pointer to a radio instance.
   Radio *radioPtr;

--- a/radioDiags/src_diags/FrequencyScanner.cc
+++ b/radioDiags/src_diags/FrequencyScanner.cc
@@ -9,9 +9,6 @@
 
 extern void nprintf(FILE *s,const char *formatPtr, ...);
 
-// This is needed to avoid race conditions upon instance destruction.
-static bool callbackEnabled;
-
 /**************************************************************************
 
   Name: signalStateCallback
@@ -38,14 +35,14 @@ static void signalStateCallback(bool signalPresent,void *contextPtr)
 {
   FrequencyScanner *thisPtr;
 
-  if (callbackEnabled)
-  {
-    // Reference the context pointer properly.
-    thisPtr = (FrequencyScanner *)contextPtr;
+  // Reference the context pointer properly.
+  thisPtr = (FrequencyScanner *)contextPtr;
 
+  if (thisPtr->isScanning())
+  {
     // Peform the processing.
     thisPtr->run(signalPresent);
-  } // ig
+  } // if
 
   return;
 
@@ -58,63 +55,49 @@ static void signalStateCallback(bool signalPresent,void *contextPtr)
   Purpose: The purpose of this function is to serve as the constructor
   of a FrequencyScanner object.
 
-  Calling Sequence: FrequencyScanner(radioPtr,
-                                     startFrequencyInHertz,
-                                     endFrequencyInHertz,
-                                     frequencyIncrementInHertz)
+  Calling Sequence: FrequencyScanner(radioPtr)
 
   Inputs:
 
     radioPtr - A pointer to a Radio instance.
-
-    startFrequencyInHertz - The start frequency of the scan.
-
-    endFrequencyInHz - The end frequency of the scan.
-
-    frequencyIncrementInHertz - The increment that is used to generate
-    the discrete frequencies. 
 
   Outputs:
 
     None.
 
 **************************************************************************/
-FrequencyScanner::FrequencyScanner(Radio *radioPtr,
-                                   uint64_t startFrequencyInHertz,
-                                   uint64_t endFrequencyInHertz,
-                                   uint64_t frequencyIncrementInHertz)
+FrequencyScanner::FrequencyScanner(Radio *radioPtr)
 {
   bool success;
 
   // Save for later use.
   this->radioPtr = radioPtr;
-  this->startFrequencyInHertz = startFrequencyInHertz;
-  this->endFrequencyInHertz = endFrequencyInHertz;
-  this->frequencyIncrementInHertz = frequencyIncrementInHertz;
+
+  // Set the parameters to harmless values.
+  startFrequencyInHertz = 162550000;
+  endFrequencyInHertz = 162550000;
+  frequencyIncrementInHertz = 0;
 
   // Start at the beginning.
   currentFrequencyInHertz = startFrequencyInHertz;
 
-  // Select initial frequency.
-  success = radioPtr->setReceiveFrequency(currentFrequencyInHertz);
+  // Indicate that a new configuration isn't available.
+  newConfigurationAvailable = false;
 
-  // Indicate that the system is scanning.
-  scannerState = Scanning;
+  // Indicate that the system is idle.
+  scannerState = Idle;
 
   //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
   // Register the callback to the IqDataProcessor.
   //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
-  // Enable the callback function.
-  callbackEnabled = true;
-
   // Retrieve the object instance.
   dataProcessorPtr = radioPtr->getIqProcessor();
 
+  // Turn off notification.
+  dataProcessorPtr->disableSignalNotification();
+
   // Register the callback.
   dataProcessorPtr->registerSignalStateCallback(signalStateCallback,this);
-
-  // Allow callback processing.
-  dataProcessorPtr->enableSignalNotification();
   //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
 
   return;
@@ -143,7 +126,7 @@ FrequencyScanner::~FrequencyScanner(void)
 {
 
   // Disable callback function processing.
-  callbackEnabled = false;
+  scannerState = Idle;
 
   // Turn off nofication.
   dataProcessorPtr->disableSignalNotification();
@@ -154,6 +137,223 @@ FrequencyScanner::~FrequencyScanner(void)
   return;
 
 } // ~FrequencyScanner
+
+/**************************************************************************
+
+  Name: setScanParameters
+
+  Purpose: The purpose of this function is to set the scan parameters of
+  the frequency scanner.
+  Note, that the scanner must be in an idle state in order to change the
+  parameters.
+
+  Calling Sequence: success = setScanParameters(startFrequencyInHertz,
+                                                endFrequencyInHertz,
+                                                frequencyIncrementInHertz)
+
+  Inputs:
+
+    startFrequencyInHertz - The start frequency of the scan.
+
+    endFrequencyInHz - The end frequency of the scan.
+
+    frequencyIncrementInHertz - The increment that is used to generate
+    the discrete frequencies. 
+
+  Outputs:
+
+    success - A flag that indicates the outcome of the operation.  A
+    value of true indicates success, and a value of false indicates
+    that the operation was not successful.  A failure would occur if
+    the scanner is currently scanning.
+
+**************************************************************************/
+bool FrequencyScanner::setScanParameters(uint64_t startFrequencyInHertz,
+                                         uint64_t endFrequencyInHertz,
+                                         uint64_t frequencyIncrementInHertz)
+{
+  bool success;
+  bool result;
+
+  // Default to failure.
+  success = false;
+
+  if (scannerState == Idle)
+  {
+    // Store the values for use during scanning.
+    this->startFrequencyInHertz = startFrequencyInHertz;
+    this->endFrequencyInHertz = endFrequencyInHertz;
+    this->frequencyIncrementInHertz = frequencyIncrementInHertz;
+
+    //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+    // Indicate that things have possibly changed.
+    // The start() method will deal with this later.
+    //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+    newConfigurationAvailable = true;
+    //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+
+    // Indicate success.
+    success = true;
+  } // if
+
+  return (success);
+
+} // setScanParameters
+
+/**************************************************************************
+
+  Name: start
+
+  Purpose: The purpose of this function is to enable the frequency
+  scanner so that it can start scanning.
+
+  Calling Sequence: success = start();
+
+  Inputs:
+
+    None.
+
+  Outputs:
+
+    success - A flag that indicates whether or not the operation was
+    successful.  A value of true indicates that the operation was
+    successful, and a value of false indicates that the frequency
+    scanner was already scanning.
+
+**************************************************************************/
+bool FrequencyScanner::start(void)
+{
+  bool success;
+  bool result;
+
+  // Default to failure.
+  success = false;
+
+  if (scannerState == Idle)
+  {
+    if (newConfigurationAvailable)
+    {
+      // Force this at the edge of the cliff.
+      currentFrequencyInHertz = endFrequencyInHertz;
+
+      // Select new frequency.
+      result = radioPtr->setReceiveFrequency(currentFrequencyInHertz);
+
+
+      // Negate the flag so that this processing occurs one time.
+      newConfigurationAvailable = false;
+    } // if
+
+    // Make state transition.
+    scannerState = Scanning;
+
+    // Allow callback notification.
+    dataProcessorPtr->enableSignalNotification();
+
+    // Indicate success.
+    success = true;
+  } // if
+
+  return (success);
+
+} // start
+
+/**************************************************************************
+
+  Name: stop
+
+  Purpose: The purpose of this function is to stop the frequency scanner
+  from scanning.
+
+  Calling Sequence: success = stop();
+
+  Inputs:
+
+    None.
+
+  Outputs:
+
+    success - A flag that indicates whether or not the operation was
+    successful.  A value of true indicates that the operation was
+    successful, and a value of false indicates that the frequency
+    scanner was already idle.
+
+**************************************************************************/
+bool FrequencyScanner::stop(void)
+{
+  bool success;
+
+  // Default to failure.
+  success = false;
+
+  if (scannerState == Scanning)
+  {
+    // Make state transition.
+    scannerState = Idle;
+
+    // Turn off nofication.
+    dataProcessorPtr->disableSignalNotification();
+
+    // Indicate success.
+    success = true;
+  } // if
+
+  return (success);
+
+} // stop
+
+/**************************************************************************
+
+  Name: isScanning
+
+  Purpose: The purpose of this function is to indicate whether or not
+  the frequency scanner is scanning.
+
+  Calling Sequence: status = isScanning()
+
+  Inputs:
+
+    None.
+
+  Outputs:
+
+    success - A flag that indicates whether or not the frequency
+    scanner is scanning.  A value of true indicates that the scanner
+    is scanning, and a value of false indicates that the scanner is
+    idle.
+
+**************************************************************************/
+bool FrequencyScanner::isScanning(void)
+{
+  bool status;
+
+  switch (scannerState)
+  {
+    case Idle:
+    {
+      // Indicate that the scanner is idle.
+      status = false;
+      break;
+    } // case
+
+    case Scanning:
+    {
+      // Indicate that the scanner is scanning.
+      status = true;
+      break;
+    } // case
+
+    default:
+    {
+      // Indicate that the scanner is idle.
+      status = false;
+      break;
+    } // case
+  } // switch
+
+  return (status);
+
+} // isScanning
 
 /**************************************************************************
 

--- a/radioDiags/src_diags/diagUi.cc
+++ b/radioDiags/src_diags/diagUi.cc
@@ -89,6 +89,7 @@ static void cmdSetRxWarp(char *bufferPtr);
 static void cmdSetSquelch(char *bufferPtr);
 static void cmdStartReceiver(char *bufferPtr);
 static void cmdStopReceiver(char *bufferPtr);
+static void cmdSetFscanValues(char *bufferPtr);
 static void cmdStartFscan(char *bufferPtr);
 static void cmdStopFscan(char *bufferPtr);
 static void cmdStartFrequencySweep(char *bufferPtr);
@@ -132,8 +133,9 @@ static const commandEntry commandTable[] =
   {"set","squelch",cmdSetSquelch},           // set squelch threshold
   {"start","receiver",cmdStartReceiver}, // start receiver
   {"stop","receiver",cmdStopReceiver}, // stop receiver
-  {"start","fscan",cmdStartFscan},
-    // start fscan startfrequency stopfrequency stepsize
+  {"set","fscanvalues",cmdSetFscanValues},
+    // set fscanvalues startfrequency stopfrequency stepsize
+  {"start","fscan",cmdStartFscan},           // start fscan
   {"stop","fscan",cmdStopFscan}, // stop fscan
   {"start","frequencysweep",cmdStartFrequencySweep}, 
     // start frequencysweep startfrequency stepsize count dwelltime
@@ -1067,6 +1069,71 @@ static void cmdStopReceiver(char *bufferPtr)
 
 /*****************************************************************************
 
+  Name: cmdSetFscanValues
+
+  Purpose: The purpose of this function is to set the frequency
+  scanner sweep parameters.
+
+  The syntax for the corresponding command is the following:
+
+    "set fscanvalues startfrequency endfrequency stepsize"
+
+  Calling Sequence: cmdSetFscanValues(bufferPtr)
+
+  Inputs:
+
+    bufferPtr - A pointer to the command parameters.
+
+  Outputs:
+
+    None.
+
+*****************************************************************************/
+static void cmdSetFscanValues(char *bufferPtr)
+{
+  bool success;
+  uint64_t startFrequency;
+  uint64_t endFrequency;
+  int64_t stepSize;
+
+  // Default to failure.
+  success = false;
+
+  // Retrieve parameters
+  sscanf(bufferPtr,"%llu %llu %lld",&startFrequency,&endFrequency,&stepSize);
+
+  // Enforce nonnegative values.
+  stepSize = abs(stepSize);
+
+  if ((startFrequency >= 24000000LL) && (startFrequency <  1700000000L)
+      && (endFrequency <= 1700000000LL) && (startFrequency < endFrequency))
+  {
+    // Configure the frequency scanner.
+    success =
+      diagUi_frequencyScannerPtr->setScanParameters(startFrequency,
+                                                    endFrequency,
+                                                    (uint64_t)stepSize);
+  } // if
+  else
+  {
+    nprintf(stderr,"Error: 24000000 <= frequency 17000000000 Hz.\n");
+  } // else
+
+  if (success)
+  {
+    nprintf(stderr,"Frequency scanner parameters set.\n");
+  } // if
+  else
+  {
+    nprintf(stderr,"Error: Frequency scanner cannot be scanning.\n");
+  } // else
+
+  return;
+
+} // cmdSetFscanValues
+
+/*****************************************************************************
+
   Name: cmdStartFscan
 
   Purpose: The purpose of this function is to start the frequency
@@ -1074,7 +1141,7 @@ static void cmdStopReceiver(char *bufferPtr)
 
   The syntax for the corresponding command is the following:
 
-    "start fscan startfrequency endfrequency stepsize"
+    "start fscan"
 
   Calling Sequence: cmdStartFscan(bufferPtr)
 
@@ -1089,34 +1156,14 @@ static void cmdStopReceiver(char *bufferPtr)
 *****************************************************************************/
 static void cmdStartFscan(char *bufferPtr)
 {
-  uint64_t startFrequency;
-  uint64_t endFrequency;
-  int64_t stepSize;
+  bool success;
 
-  if (diagUi_frequencyScannerPtr == 0)
+  // Start the scanner.
+  success = diagUi_frequencyScannerPtr->start();
+
+  if (success)
   {
-    // Retrieve parameters
-    sscanf(bufferPtr,"%llu %llu %lld",&startFrequency,&endFrequency,&stepSize);
-
-    // Enforce nonnegative values.
-    stepSize = abs(stepSize);
-
-    if ((startFrequency >= 24000000LL) && (startFrequency < 1700000000LL)
-        && (endFrequency <= 1700000000LL) && (startFrequency < endFrequency))
-    {
-      // Start the frequency scanner.
-      diagUi_frequencyScannerPtr = new FrequencyScanner(diagUi_radioPtr,
-                                                        startFrequency,
-                                                        endFrequency,
-                                                        (uint64_t)stepSize);
-
-      nprintf(stderr,"Frequency scanning started.\n");
-    } // if
-    else
-    {
-      nprintf(stderr,"Error: 24000000 <= frequency 17000000000 Hz.\n");
-    } // else
-
+    nprintf(stderr,"Frequency scanning started.\n");
   } // if
   else
   {
@@ -1150,17 +1197,19 @@ static void cmdStartFscan(char *bufferPtr)
 *****************************************************************************/
 static void cmdStopFscan(char *bufferPtr)
 {
+  bool success;
 
-  if (diagUi_frequencyScannerPtr != 0)
+  // Start the scanner.
+  success = diagUi_frequencyScannerPtr->stop();
+
+  if (success)
   {
-    // Stop the frequency scanner.
-    delete diagUi_frequencyScannerPtr;
-
-    // Indicate that frequency scan has been stopped.
-    diagUi_frequencyScannerPtr = 0;
-
     nprintf(stderr,"Frequency scan stopped.\n");
   } // if
+  else
+  {
+    nprintf(stderr,"Error: Frequency scanning is already stopped.\n");
+  } // else
 
   return;
 
@@ -1460,7 +1509,10 @@ static void cmdHelp(void)
   nprintf(stderr,"set squelch <threshold>\n");
   nprintf(stderr,"start receiver\n");
   nprintf(stderr,"stop receiver\n");
-  nprintf(stderr,"start fscan <startfrequency> <endfrequency> <stepsize>\n");
+  nprintf(stderr,
+      "set fscanvalues <startfrequency> <endfrequency> <stepsize>\n");
+
+  nprintf(stderr,"start fscan\n");
   nprintf(stderr,"stop fscan\n");
 
   nprintf(stderr,  

--- a/radioDiags/src_diags/radioApp.cc
+++ b/radioDiags/src_diags/radioApp.cc
@@ -68,7 +68,6 @@ FrequencySweeper *diagUi_frequencySweeperPtr;
 //
 // Anyway, enjoy! Chris G.06/06/2017
 //*************************************************************************
-
 /*****************************************************************************
 
   Name: processPcmData
@@ -119,7 +118,7 @@ int main(int argc,char **argv)
   diagUi_radioPtr->setReceiveFrequency(receiveFrequency);
 
   // Indicate that no frequency scanner has been allocated.
-  diagUi_frequencyScannerPtr = 0;
+  diagUi_frequencyScannerPtr = new FrequencyScanner(diagUi_radioPtr);
 
   // Indicate that no frequency sweeper has been allocated.
   diagUi_frequencySweeperPtr = 0;


### PR DESCRIPTION
1. Responsibility of instantiation of the frequency scanner has been moved
from the diag UI to the mainline code.

2. The user now has to configure the frequency scanner before starting a
scan if new frequency parameters are desired.

3. The user can enable/disable the scanner without having to change the
scanning parameters.  This allows the user to stop scanning (which
provides pause functionality), and restart the scan with the result that
the scan will continue from the last frequency for which the scanner was
stopped.

4. The frequency scanner exists for the whole lifetime of the program.

This should make things easier when if I decide to absorb scanner
functionality into the Radio object. For now, I'll let it be a separate
Radio object application.