### PR TITLE
Code was added to disallow the AGC from being enabled while the receiver

### DIFF
--- a/radioDiags/src_diags/AutomaticGainControl.cc
+++ b/radioDiags/src_diags/AutomaticGainControl.cc
@@ -400,31 +400,41 @@ bool  AutomaticGainControl::setAgcFilterCoefficient(float coefficient)
 
     success - A flag that indicates whether or not the operation was
     successful.  A value of true indicates that the operation was
-    successful, and a value of false indicates that the AGC was already
-    enabled.
+    successful, and a value of false indicates that, eitherthe AGC
+    was already enabled, or the radio was not in a receiving state.
 
 **************************************************************************/
 bool AutomaticGainControl::enable(void)
 {
   bool success;
   IqDataProcessor *DataProcessorPtr;
+  Radio *RadioPtr;
 
-  // Reference the pointer in the proper context.
+  // Reference the pointers in the proper context.
   DataProcessorPtr = (IqDataProcessor *)dataProcessorPtr;
+  RadioPtr = (Radio *)radioPtr;
 
   // Default to failure.
   success = false;
 
-  if (!enabled)
+  //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+  // Ensure that the radio is already in the receiving state so
+  // that AGC transients do not occur when the receiver is
+  // first enabled.
+  //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+  if (RadioPtr->isReceiving())
   {
-    // Enable the AGC.
-    enabled = true;
+    if (!enabled)
+    {
+      // Enable the AGC.
+      enabled = true;
 
-    // Allow callback notification.
-    DataProcessorPtr->enableSignalMagnitudeNotification();
+      // Allow callback notification.
+      DataProcessorPtr->enableSignalMagnitudeNotification();
 
-    // Indicate success.
-    success = true;
+      // Indicate success.
+      success = true;
+    } // if
   } // if
 
   return (success);

--- a/radioDiags/src_diags/Radio.cc
+++ b/radioDiags/src_diags/Radio.cc
@@ -554,6 +554,9 @@ void Radio::stopReceiver(void)
     // The radio is stopped, so we're done..
     requestReceiverToStop = false;
 
+    // Disable the AGC to avoid startup transients later.
+    agcPtr->disable();
+
     // Release the radio lock.
     pthread_mutex_unlock(&radioLock);
   } // if
@@ -1015,7 +1018,7 @@ bool Radio::setSignalDetectThreshold(int32_t threshold)
   // Default to failure.
   success = false;
 
-  if ((threshold >= (-100)) && (threshold <= 10))
+  if ((threshold >= (-400)) && (threshold <= 10))
   {
     // Inform data processor of new threshold.
     receiveDataProcessorPtr->setSignalDetectThreshold(threshold);

--- a/radioDiags/src_diags/diagUi.cc
+++ b/radioDiags/src_diags/diagUi.cc
@@ -816,7 +816,7 @@ static void cmdEnableAgc(char *bufferPtr)
   } // if
   else
   {
-    nprintf(stderr,"Error: AGC is already enabled.\n");  
+    nprintf(stderr,"Error: AGC is already enabled or receiver is disabled\n");  
   } // else
 
   return;


### PR DESCRIPTION
is not enabled. Additionally, when the receiver is disable, the AGC is
disabled. This prevents AGC transients when the receiver is first enabled.