### PR TITLE
I think an AGC operating point of -12dBFs seems to work best across the

### DIFF
--- a/radioDiags/src_diags/Radio.cc
+++ b/radioDiags/src_diags/Radio.cc
@@ -172,8 +172,8 @@ Radio::Radio(int deviceNumber,uint32_t rxSampleRate,
     // Set the demodulation mode.
     receiveDataProcessorPtr->setDemodulatorMode(IqDataProcessor::Fm);
 
-    // Instantiate an AGC with an operating point of -8dBFs.
-    agcPtr = new AutomaticGainControl(this,-8);
+    // Instantiate an AGC with an operating point of -12dBFs.
+    agcPtr = new AutomaticGainControl(this,-12);
 
     // Create the event consumer thread.
     pthread_create(&eventConsumerThread,0,


### PR DESCRIPTION
board.  I initially increased the gain to -8dBFs to mitigate limit cycle
occurrances.  I believe I've reduced the probability of this occuring now.
There is still more work to be done.