### PR TITLE
The following changes have been incorported.

### DIFF
--- a/doc/agcResearch/README.txt
+++ b/doc/agcResearch/README.txt
@@ -49,8 +49,8 @@ Time (Adjust IF gain): 15 to 19ms.
 
 The total time always is 19ms. This means that 19ms of a 64ms IQ data
 block has already arrived.  The solution is to adjust the receiver gain
-and skip signal evaluation of the poluted IQ data block.  This is
-accomplished by setting the AGC blank value to 2.  This will mitigate the
+and skip signal evaluation of the polluted IQ data block.  This is
+accomplished by setting the AGC blank value to 1.  This will mitigate the
 effect of the AGC "fishtailing" due to the inherent latency of data transfer
 through the radio appliction.
 The latency is due to:

--- a/radioDiags/hdr_diags/AutomaticGainControl.h
+++ b/radioDiags/hdr_diags/AutomaticGainControl.h
@@ -42,6 +42,7 @@ class AutomaticGainControl
   //*****************************************
   // Utility functions.
   //*****************************************
+  void resetBlankingSystem(void);
   int32_t convertMagnitudeToDbFs(uint32_t signalMagnitude);
 
   //*****************************************
@@ -53,6 +54,7 @@ class AutomaticGainControl
   // These parameters are sometimes needed to avoid transients.
   uint32_t blankingCounter;
   uint32_t blankingLimit;
+  bool receiveGainWasAdjusted;
 
   // Yes, we need some deadband.
   int32_t deadbandInDb;


### PR DESCRIPTION
1. A resetBlankingSystem() function has been added.
2. The code in the run() function has been cleaned up.
3. Blanking only occurs if a gain adjustment has occurred.
4. The semantics of the blank timeout and blank counter have been changed.
The blank timeout really maps to a blanking interval in ticks.  For example,
if the blank timeout is set to 3, then after a gain adjustment, the AGC will
ignore the following three IQ data blocks, thus, no gain adjustment will
occur.