### PR TITLE
I hate to use global variables, but this gives me a realtime view (al…

### DIFF
--- a/radioDiags/src_diags/AutomaticGainControl.cc
+++ b/radioDiags/src_diags/AutomaticGainControl.cc
@@ -18,6 +18,9 @@
 
 #include "AutomaticGainControl.h"
 
+// The current variable gain setting.
+extern int32_t radio_adjustableReceiveGainInDb;
+
 //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
 // Hardware-dependent defines.
 //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
@@ -692,6 +695,19 @@ void AutomaticGainControl::run(uint32_t signalMagnitude)
 
   // Default to not being able to run.
   allowedToRun = false;
+
+  //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+  // This block of code deals with the case where some external
+  // entity adjusted the receiver IF gain without knowledge of
+  // the AGC.  If this block of code were not here, data
+  // inconsistancy can occur between the hardware setting of
+  // the IF gain, and the AGC's idea of what the gain should be.
+  //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+  if (ifGainInDb != (uint32_t)radio_adjustableReceiveGainInDb)
+  {
+    ifGainInDb = (uint32_t)radio_adjustableReceiveGainInDb;
+  } // if
+  //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
 
   //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
   // This block of code ensures that if a gain adjustment was


### PR DESCRIPTION
…most)

of the hardware setting of the IF gain.  There was a race condition if the user changed the IF gain through the user interface, such that the AGC was not aware of this change.  Under some conditions, I saw data consisconstnacy between the AGC's notion of the IF gain and the hardware setting of the IF gain.  I'll beat on this code before I decide to merge this branch into master.  Once I prove that this works, I'll make the same changes (almost) into my HackRF diags.