### PR TITLE
The original differentiator coefficients were wrong. Someone forgot t…

### DIFF
--- a/radioDiags/FmDemodulator/FmDemodulator.cc
+++ b/radioDiags/FmDemodulator/FmDemodulator.cc
@@ -133,6 +133,7 @@ static float differentiatorCoefficients[] =
   1,
   0,
   -1,
+  0,
   1/16
 };
 


### PR DESCRIPTION
…o put

a 0 in the middle of the filter coefficient sequence, with the result that the filter was not linear phase. I fixed it. The performance using this 6-tap FIR filter is significantly improved over that of a first order difference equation.